### PR TITLE
Re-order some of the README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Silverstripe Search is designed to integrate easily with the Silverstripe CMS. T
 Before you can get stared with this SDK you will need:
 
 - A Silverstripe CMS application
-- Bifröst Environment variables (provided when you sign up for Silverstripe Search Service)
+- Bifröst Environment variables (provided when you sign up for Silverstripe Search)
 
 ## Installation
 
@@ -17,54 +17,26 @@ To install the complete SDK run
 composer require silverstripe/silverstripe-search-sdk
 ```
 
-### Installed modules
-
-These packages are included with the full SDK
-
-|Package| Description|
-|-----|------|
-|`silverstripe/silverstripe-discoverer` | Supports querying features |
-|`silverstripe/silverstripe-discoverer-bifrost` | Silverstripe Search specific features for `silverstripe/silverstripe-discoverer` |
-|`silverstripe/silverstripe-discoverer-elastic-enterprise` | Elastic search dependency for  `silverstripe/silverstripe-discoverer-bifrost` |
-|`silverstripe/silverstripe-forager` | Supports search content management (configuration, document indexing) |
-|`silverstripe/silverstripe-forager-bifrost` | Silverstripe Search specific features for `silverstripe/silverstripe-forager`  |
-|`silverstripe/silverstripe-forager-elastic-enterprise` | Elastic search dependency for  `silverstripe/silverstripe-forager-bifrost` |
-|`silverstripe/silverstripe-discoverer-search-ui` | Base User interface features such as a Controller, Page Type and Templates |
-
-## 🛼 Roll-your-own installation
-
-If you want to dial in your installation you can manually add the packages in the following groups:
-
-### Querying
-
-The [silverstripe/silverstripe-discoverer](https://github.com/silverstripeltd/silverstripe-discoverer) module contains provider-agnostic interfaces for performing search queries, including filtering and faceting. The [silverstripe/silverstripe-discoverer-bifrost](https://github.com/silverstripeltd/silverstripe-discoverer-bifrost) contains Silverstripe Search specific implementation to connect you with our Bifröst API. 
-
-Refer to the [silverstripe/silverstripe-discoverer docs](https://github.com/silverstripeltd/silverstripe-discoverer) for more information on its use.
-
-### Search Content management
-The [silverstripe/silverstripe-forager](https://github.com/silverstripeltd/silverstripe-forager) module contains provider-agnostic interfaces and admin UI for configuring the service and index management.  The [silverstripe/silverstripe-forager-bifrost](https://github.com/silverstripeltd/silverstripe-forager-bifrost) contains Silverstripe Search specific implementation to connect you with our Bifröst API. 
-
-Refer to the [silverstripe/silverstripe-forager docs](https://github.com/silverstripeltd/silverstripe-forager) for more information on its use.
-
-### Search UI
-
-The [silverstripe/silverstripe-discoverer-search-ui](https://github.com/silverstripeltd/silverstripe-discoverer-search-ui) module contains the base parts to show results on a Search page including a Page Type, Controller and templates.
-
-
 ## Using the SDK
 
-To get started you will need to add the Bifröst Environment variables (provided when you sign up for Silverstripe Search Service). For local development this is normally done in your `.env` file and should look like the following:
+### Environment variables
+
+To get started you will need to add the Bifröst environment variables (provided when you sign up for Silverstripe Search). 
+
+For local development this is normally done in your `.env` file and should look like the following:
 
 ```
 BIFROST_ENDPOINT=<< provided on sign up >>
+BIFROST_ENGINE_PREFIX=<< provided on sign up >>
 BIFROST_MANAGEMENT_API_KEY=<< provided on sign up >>
 BIFROST_QUERY_API_KEY=<< provided on sign up >>
-BIFROST_ENGINE_PREFIX=<< provided on sign up >>
 ```
 
+For Silverstripe Cloud, you should add `BIFROST_ENDPOINT` and `BIFROST_ENGINE_PREFIX` as Variables, and `BIFROST_MANAGEMENT_API_KEY` and `BIFROST_QUERY_API_KEY` should be added as Secrets.
 
 ### Configuration
-You will also need to set up an initial index config file. We suggest using `app/_config/search.yml` so its easy to find later. A simple index with that just indexes Pages titles would look like:
+
+You will also need to set up an initial index config file. We suggest using `app/_config/search.yml` so its easy to find later. A simple index that just indexes Page titles would look like:
 
 ```YAML
 SilverStripe\Forager\Service\IndexConfiguration:
@@ -77,12 +49,32 @@ SilverStripe\Forager\Service\IndexConfiguration:
               property: Title
 ``` 
 
-Here the name of the index is `main` this is added to your `BIFROST_ENGINE_PREFIX` to give the full name of your index. E.g. if the `BIFROST_ENGINE_PREFIX=search-acme-ltd` then this index's full name is `search-acme-ltd-main`.
+Here the name of the index variant is `main`. This is added to your `BIFROST_ENGINE_PREFIX` to give the full name of your index. E.g. if the `BIFROST_ENGINE_PREFIX=search-acme-prod` then this index's full name is `search-acme-prod-main`.
 
-There are a range options for you to customise your indexing to get the most out of your content. Refer to the [forager customisation docs](https://github.com/silverstripeltd/silverstripe-forager/blob/1.0.0/docs/en/configuration.md) for more information. 
+There are a range of options for you to customise your indexing to get the most out of your content. Refer to the [Forager configuration docs](https://github.com/silverstripeltd/silverstripe-forager/blob/1.0.0/docs/en/configuration.md) for more information. 
 
 > [!WARNING]
 > Once you add a field to an index you cannot change its name or type without deleting the engine so choose field names carefully
+
+## 🛼 Roll-your-own installation
+
+If you want to dial in your installation you can manually add the packages in the following groups:
+
+### Querying
+
+The [silverstripe/silverstripe-discoverer](https://github.com/silverstripeltd/silverstripe-discoverer) module contains provider-agnostic interfaces for performing search queries, including filtering and faceting. The [silverstripe/silverstripe-discoverer-bifrost](https://github.com/silverstripeltd/silverstripe-discoverer-bifrost) contains Silverstripe Search specific implementation to connect you with our Bifröst API. 
+
+Refer to the [silverstripe/silverstripe-discoverer docs](https://github.com/silverstripeltd/silverstripe-discoverer) for more information on its use.
+
+### Search Content management
+
+The [silverstripe/silverstripe-forager](https://github.com/silverstripeltd/silverstripe-forager) module contains provider-agnostic interfaces and admin UI for configuring the service and index management. The [silverstripe/silverstripe-forager-bifrost](https://github.com/silverstripeltd/silverstripe-forager-bifrost) contains Silverstripe Search specific implementation to connect you with our Bifröst API. 
+
+Refer to the [silverstripe/silverstripe-forager docs](https://github.com/silverstripeltd/silverstripe-forager) for more information on its use.
+
+### Search UI
+
+The [silverstripe/silverstripe-discoverer-search-ui](https://github.com/silverstripeltd/silverstripe-discoverer-search-ui) module contains the base parts to show results on a Search page including a Page Type, Controller, templates, and basic styling.
 
 ### Search page and results
 


### PR DESCRIPTION
- Re-ordered some of the sections to what I thought might feel like a nicer flow for users who just want to install and get up and running.
- Removed the `Installed modules` section. I think it's probably too much info for regular users, and anyone who is curious (or a power user) will likely know how to use the `composer.json`.
- Some minor wording changes.